### PR TITLE
include missing '-bare' versionsuffix for Perl builddep in ZPAQ easyconfig

### DIFF
--- a/easybuild/easyconfigs/z/ZPAQ/ZPAQ-7.00-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/z/ZPAQ/ZPAQ-7.00-GCC-4.8.2.eb
@@ -22,7 +22,7 @@ sources = ['%%(namelower)s%s.zip' % ''.join(version.split('.'))]
 source_urls = ['http://mattmahoney.net/dc/']
 
 builddependencies = [
-    ('Perl', '5.20.1'),  # required for pod2man
+    ('Perl', '5.20.1', '-bare'),  # required for pod2man
 ]
 
 buildopts = " && pod2man zpaq.pod > zpaq.1"


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/1242
